### PR TITLE
Add password reset

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :development, :test do
   gem 'byebug',                '11.1.3', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails' #テスト用 "Rspec"
   gem 'factory_bot_rails' #テスト用
+  gem 'rails-controller-testing', '1.0.5' #テスト用(assigns)
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 6.0.3.1)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -242,6 +246,7 @@ DEPENDENCIES
   pg (= 1.2.3)
   puma (= 4.3.5)
   rails (= 6.0.3.1)
+  rails-controller-testing (= 1.0.5)
   rails-i18n (~> 6.0)
   rspec-rails
   sass-rails (= 6.0.0)

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -136,6 +136,10 @@ $gray-medium-light: #eaeaea;
   font-size: 0.9em;
 }
 
+.form-go-to-password-reset {
+  font-size: 0.9em;
+}
+
 #error_explanation {
   color: red;
   ul {

--- a/app/assets/stylesheets/password_resets.scss
+++ b/app/assets/stylesheets/password_resets.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the PasswordResets controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,62 @@
+class PasswordResetsController < ApplicationController
+  before_action :get_user,         only: [:edit, :update]
+  before_action :valid_user,       only: [:edit, :update]
+  before_action :check_expiration, only: [:edit, :update]
+
+  def new
+  end
+
+  def create
+    @user = User.find_by(email: params[:password_reset][:email].downcase)
+    if @user
+      @user.create_reset_digest
+      @user.send_password_reset_email
+      flash[:info] = "パスワード再設定メールが送信されました"
+      redirect_to root_url
+    else
+      flash[:danger] = "メールアドレスが正しくありません"
+      render 'new'
+    end
+  end
+
+  def edit
+  end
+
+  def update #パスワード入力
+    if params[:user][:password].empty? #空の場合
+      @user.errors.add(:password, :blank)
+      render 'edit'
+    elsif @user.update(user_params) #正しく入力された場合
+      log_in @user
+      @user.update_attribute(:reset_digest, nil)
+      flash[:success] = "パスワードの再設定が完了しました"
+      redirect_to @user
+    else #その他、間違って入力された場合
+      render 'edit'
+    end
+  end
+
+  private
+
+    def user_params #ストロングパラメータ
+      params.require(:user).permit(:password, :password_confirmation)
+    end
+
+    def get_user
+      @user = User.find_by(email: params[:email])
+    end
+
+    def valid_user
+      unless (@user && @user.activated? && @user.authenticated?(:reset, params[:id]))
+        flash[:danger] = "無効なURLです。再度メールアドレスを入力してください"
+        redirect_to new_password_reset_url
+      end
+    end
+
+    def check_expiration
+      if @user.password_reset_expired?
+        flash[:danger] = "パスワード再設定URLの有効期限が過ぎています。再度メールアドレスを入力してください"
+        redirect_to new_password_reset_url
+      end
+    end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -53,7 +53,7 @@ class UsersController < ApplicationController
       redirect_to root_url
     else
       @user = User.find(params[:id])
-      if @user.update_attributes(user_params)
+      if @user.update(user_params)
         #編集(更新)成功
         flash[:success] = "アカウントの編集に成功しました"
         redirect_to @user #user_url(@user)

--- a/app/helpers/password_resets_helper.rb
+++ b/app/helpers/password_resets_helper.rb
@@ -1,0 +1,2 @@
+module PasswordResetsHelper
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -2,12 +2,11 @@ class UserMailer < ApplicationMailer
 
   def account_activation(user)
     @user = user
-    mail to: user.email, subject: "【重要】Anime Searcherよりアカウント有効化メールをお届けしました"
+    mail to: user.email, subject: "【Anime Searcher】アカウント有効化メール"
   end
 
-  def password_reset
-    @greeting = "Hi"
-
-    mail to: "to@example.org"
+  def password_reset(user)
+    @user = user
+    mail to: user.email, subject: "【Anime Searcher】パスワード再設定メール"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   #仮想的な属性：「remember_token」属性を作成する（実際にはcookiesに属する）
-  attr_accessor :remember_token, :activation_token
+  attr_accessor :remember_token, :activation_token, :reset_token
 
   before_save :downcase_email
   before_create :create_activation_digest
@@ -78,6 +78,24 @@ class User < ApplicationRecord
   # 有効化用のメールを送信する
   def send_activation_email
     UserMailer.account_activation(self).deliver_now
+  end
+
+  # パスワード再設定の属性を設定する
+  def create_reset_digest
+    self.reset_token = User.new_token
+    # update_attribute(:reset_digest,  User.digest(reset_token))
+    # update_attribute(:reset_sent_at, Time.zone.now)
+    update_columns(reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now)
+  end
+
+  # パスワード再設定のメールを送信する
+  def send_password_reset_email
+    UserMailer.password_reset(self).deliver_now
+  end
+
+  # パスワード再設定URLの有効期限
+  def password_reset_expired?
+    reset_sent_at < 2.hours.ago
   end
 
   private

--- a/app/views/password_resets/create.html.erb
+++ b/app/views/password_resets/create.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#create</h1>
+<p>Find me in app/views/password_resets/create.html.erb</p>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,26 @@
+<% provide(:title, "パスワード再設定") %>
+<div class="row bg-light">
+  <div class="container">
+    <div class="form-container jumbotron">
+      <h1 class="form-title">パスワード再設定</h1>
+      <%= form_with(model: @user, url: password_reset_path(params[:id]), scope: :password_reset, local: true) do |f| %>
+        <%= render 'shared/error_messages' %>
+
+        <%= hidden_field_tag :email, @user.email %>
+        <div class="form-group">
+          <%#= f.label :password, "パスワード", class: 'form-control-label' %>
+          <%= f.password_field :password, class: 'form-control', placeholder: "パスワード" %>
+        </div>
+
+        <div class="form-group">
+          <%#= f.label :password_confirmation, "パスワード（再入力）", class: 'form-control-label' %>
+          <%= f.password_field :password_confirmation, class: 'form-control', placeholder: "パスワード（再入力）" %>
+        </div>
+
+        <div class="form-group">
+          <%= f.submit "送信", class: "btn btn-info btn-lg form-submit" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,21 @@
+<% provide(:title, "パスワード再設定メール送信") %>
+<div class="row bg-light">
+  <div class="container">
+    <div class="form-container jumbotron">
+      <h1 class="form-title">パスワード再設定</h1>
+      <%= form_with(url: password_resets_path, scope: :password_reset, local: true) do |f| %>
+
+        <div class="form-group">
+          <%#= f.label :email, "メールアドレス", class: 'form-control-label' %>
+          <%= f.email_field :email, class: 'form-control', placeholder: "メールアドレス" %>
+        </div>
+
+        <div class="form-group">
+          <%= f.submit "送信", class: "btn btn-info btn-lg form-submit" %>
+        </div>
+      <% end %>
+
+      <p class="form-go-to-signup-or-login"> ▶︎ <%= link_to "ログイン画面", login_path %>に戻る</p>
+    </div>
+  </div>
+</div>

--- a/app/views/password_resets/update.html.erb
+++ b/app/views/password_resets/update.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#update</h1>
+<p>Find me in app/views/password_resets/update.html.erb</p>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -28,7 +28,8 @@
         </div>
       <% end %>
 
-      <p class="form-go-to-signup-or-login"> ▶︎ <%= link_to "新しくアカウントを作成する", signup_path %></p>
+      <p class="form-go-to-signup-or-login"> ▶︎ 新しくアカウントを<%= link_to "作成する", signup_path %></p>
+      <p class="form-go-to-password-reset"> ▶︎ パスワードを忘れた場合は<%= link_to "こちら", new_password_reset_path %></p>
     </div>
   </div>
 </div>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,5 +1,8 @@
-<h1>User#password_reset</h1>
+<h1>Anime Searcher</h1>
 
-<p>
-  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
-</p>
+<p><%= @user.name %> さんへ<p>
+
+<p>下記のURLをクリックして、パスワードの再設定を行ってください。</p>
+
+<%= link_to "アカウントを有効にする", edit_password_reset_url(@user.reset_token,
+                                                    email: @user.email) %>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,3 +1,7 @@
-User#password_reset
+Anime Searcher
 
-<%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb
+<%= @user.name %> さんへ
+
+下記のURLをクリックして、パスワードの再設定を行ってください。
+
+<%= edit_password_reset_url(@user.reset_token, email: @user.email) %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,6 +34,7 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.delivery_method = :test #追加
   host = 'localhost:3000' #追加
   config.action_mailer.default_url_options = { host: host, protocol: 'http' } #追加
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,5 @@ Rails.application.routes.draw do
   post '/guest', to: 'guest_sessions#create' #ゲストログイン
   resources :users
   resources :account_activations, only: [:edit]
+  resources :password_resets, only: [:new, :create, :edit, :update]
 end

--- a/db/migrate/20200818045555_add_reset_to_users.rb
+++ b/db/migrate/20200818045555_add_reset_to_users.rb
@@ -1,0 +1,6 @@
+class AddResetToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_05_203448) do
+ActiveRecord::Schema.define(version: 2020_08_18_045555) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
@@ -22,6 +22,8 @@ ActiveRecord::Schema.define(version: 2020_08_05_203448) do
     t.boolean "admin", default: false
     t.string "activation_digest"
     t.boolean "activated", default: false
+    t.string "reset_digest"
+    t.datetime "reset_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/helpers/password_resets_helper_spec.rb
+++ b/spec/helpers/password_resets_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PasswordResetsHelper. For example:
+#
+# describe PasswordResetsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe PasswordResetsHelper, type: :helper do
+  # pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -10,7 +10,9 @@ class UserMailerPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
   def password_reset
-    UserMailer.password_reset
+    user = User.first
+    user.reset_token = User.new_token
+    UserMailer.password_reset(user)
   end
 
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -7,42 +7,25 @@ RSpec.describe UserMailer, type: :mailer do
     it "renders mails" do
       user.activation_token = User.new_token
       mail = UserMailer.account_activation(user)
-      expect(mail.subject).to eq("【重要】Anime Searcherよりアカウント有効化メールをお届けしました")
+      expect(mail.subject).to eq("【Anime Searcher】アカウント有効化メール")
       expect(mail.to).to eq(["michael@example.com"])
       expect(mail.from).to eq(["noreply@example.com"])
       # expect(mail.body.encoded).to include("Michael Example")
       # ...はエンコードの関係で通らない。
       expect(mail.body.encoded.split(/\r\n/).map{|i| Base64.decode64(i)}.join).to include("Michael Example")
     end
-    # let(:mail) { UserMailer.account_activation(user) }
-    #
-    # # メール送信のテスト
-    # it "renders the headers" do
-    #   expect(mail.from).to eq ["noreply@example.com"]
-    #   expect(mail.to).to eq ["michael@example.com"]
-    #   expect(mail.subject).to eq "アカウント有効化 - Anime Searcher"
-    # end
-
-    # メールプレビューのテスト #エンコードがbase64の為、テスト通らない
-    # it "renders the body" do
-    #   expect(mail.body).to match user.name
-    #   expect(mail.body).to match user.activation_token
-    #   expect(mail.body).to match CGI.escape(user.email)
-    # end
   end
 
-  # describe "password_reset" do
-  #   let(:mail) { UserMailer.password_reset }
-  #
-  #   it "renders the headers" do
-  #     expect(mail.subject).to eq("Password reset")
-  #     expect(mail.to).to eq(["to@example.org"])
-  #     expect(mail.from).to eq(["from@example.com"])
-  #   end
-  #
-  #   it "renders the body" do
-  #     expect(mail.body.encoded).to match("Hi")
-  #   end
-  # end
-
+  describe "password_reset" do
+    it "renders mails" do
+      user.reset_token = User.new_token
+      mail = UserMailer.password_reset(user)
+      expect(mail.subject).to eq("【Anime Searcher】パスワード再設定メール")
+      expect(mail.to).to eq(["michael@example.com"])
+      expect(mail.from).to eq(["noreply@example.com"])
+      expect(mail.body.encoded.split(/\r\n/).map{|i| Base64.decode64(i)}.join).to include "Michael Example"
+      expect(mail.body.encoded.split(/\r\n/).map{|i| Base64.decode64(i)}.join).to include user.reset_token
+      expect(mail.body.encoded.split(/\r\n/).map{|i| Base64.decode64(i)}.join).to include CGI.escape(user.email)
+    end
+  end
 end

--- a/spec/requests/account_activations_request_spec.rb
+++ b/spec/requests/account_activations_request_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe "AccountActivations", type: :request do
-
 end

--- a/spec/requests/guest_sessions_request_spec.rb
+++ b/spec/requests/guest_sessions_request_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe "GuestSessions", type: :request do
-
 end

--- a/spec/requests/password_resets_request_spec.rb
+++ b/spec/requests/password_resets_request_spec.rb
@@ -1,0 +1,146 @@
+require 'rails_helper'
+
+RSpec.describe "PasswordResets", type: :request do
+
+  let(:user) { create(:user) }
+
+  # createアクション
+  describe "POST /password_resets" do
+    # 無効なメールアドレス
+    it "is invalid email adress" do
+      get new_password_reset_path
+      expect(request.fullpath).to eq '/password_resets/new'
+      post password_resets_path, params: { password_reset: { email: "" } }
+      expect(flash[:danger]).to be_truthy
+      expect(request.fullpath).to eq '/password_resets'
+    end
+    # 有効なメールアドレス
+    it "is valid email adress" do
+      get new_password_reset_path
+      expect(request.fullpath).to eq '/password_resets/new'
+      post password_resets_path, params: { password_reset: { email: user.email } }
+      expect(flash[:info]).to be_truthy
+      expect(flash[:danger]).to be_falsey
+      follow_redirect!
+      expect(request.fullpath).to eq '/'
+    end
+  end
+
+  # editアクション（メール送信〜URLクリック）
+  describe "GET /password_resets/:id/edit" do
+    # 無効なメールアドレス
+    it "is invalid email adress" do
+      post password_resets_path, params: { password_reset: { email: user.email } }
+      user = assigns(:user)
+      get edit_password_reset_path(user.reset_token, email: "")
+      expect(flash[:danger]).to be_truthy
+      follow_redirect!
+      expect(request.fullpath).to eq '/password_resets/new'
+    end
+
+    # 無効なユーザー
+    it "is invalid user" do
+      post password_resets_path, params: { password_reset: { email: user.email } }
+      user = assigns(:user)
+      user.toggle!(:activated)
+      get edit_password_reset_path(user.reset_token, email: user.email)
+      expect(flash[:danger]).to be_truthy
+      follow_redirect!
+      expect(request.fullpath).to eq '/password_resets/new'
+      user.toggle!(:activated)
+    end
+
+    # 無効なトークン
+    it "is invalid reset_token" do
+      post password_resets_path, params: { password_reset: { email: user.email } }
+      user = assigns(:user)
+      get edit_password_reset_path('wrong token', email: user.email)
+      expect(flash[:danger]).to be_truthy
+      follow_redirect!
+      expect(request.fullpath).to eq '/password_resets/new'
+    end
+
+    # 有効なメールアドレス・ユーザー・トークン
+    it "is valid information" do
+      post password_resets_path, params: { password_reset: { email: user.email } }
+      user = assigns(:user)
+      get edit_password_reset_path(user.reset_token, email: user.email)
+      expect(flash[:danger]).to be_falsey
+      expect(request.fullpath).to eq "/password_resets/#{user.reset_token}/edit?email=#{CGI.escape(user.email)}"
+    end
+  end
+
+  # updateアクション（新旧パスワード入力画面）
+  describe "PATCH /password_resets/:id" do
+    # 無効なパスワード
+    it "is invalid password" do
+      post password_resets_path, params: { password_reset: { email: user.email } } #メール送信
+      user = assigns(:user)
+      get edit_password_reset_path(user.reset_token, email: user.email) #送られてきたURLをクリック
+      #パスワード入力画面
+      patch password_reset_path(user.reset_token), params: {
+        email: user.email,
+        user: {
+          password: "foobar",
+          password_confirmation: "barbaz"
+        }
+      }
+      expect(request.fullpath).to eq "/password_resets/#{user.reset_token}"
+    end
+
+    # 空のパスワード
+    it "is empty password" do
+      post password_resets_path, params: { password_reset: { email: user.email } } #メール送信
+      user = assigns(:user)
+      get edit_password_reset_path(user.reset_token, email: user.email) #送られてきたURLをクリック
+      #パスワード入力画面
+      patch password_reset_path(user.reset_token), params: {
+        email: user.email,
+        user: {
+          password: "",
+          password_confirmation: ""
+        }
+      }
+      expect(request.fullpath).to eq "/password_resets/#{user.reset_token}"
+    end
+
+    # 期限切れのトークン
+    it "has expired token" do
+      post password_resets_path, params: { password_reset: { email: user.email } } #メール送信
+      user = assigns(:user)
+      user.update_attribute(:reset_sent_at, 3.hours.ago) #トークン発行後３時間が経過（＞２時間）
+      get edit_password_reset_path(user.reset_token, email: user.email) #送られてきたURLをクリック
+      #パスワード入力画面
+      patch password_reset_path(user.reset_token), params: {
+        email: user.email,
+        user: {
+          password: "foobaz",
+          password_confirmation: "foobaz"
+        }
+      }
+      expect(flash[:danger]).to be_truthy
+      follow_redirect!
+      expect(request.fullpath).to eq "/password_resets/new"
+    end
+
+    # 有効なパスワード
+    it "is valid information" do
+      post password_resets_path, params: { password_reset: { email: user.email } } #メール送信
+      user = assigns(:user)
+      get edit_password_reset_path(user.reset_token, email: user.email) #送られてきたURLをクリック
+      #パスワード入力画面
+      patch password_reset_path(user.reset_token), params: {
+        email: user.email,
+        user: {
+          password: "foobaz",
+          password_confirmation: "foobaz"
+        }
+      }
+      expect(flash[:success]).to be_truthy
+      expect(is_logged_in?).to be_truthy
+      follow_redirect!
+      expect(request.fullpath).to eq "/users/1"
+    end
+  end
+
+end

--- a/spec/views/password_resets/create.html.erb_spec.rb
+++ b/spec/views/password_resets/create.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "password_resets/create.html.erb", type: :view do
+  # pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/password_resets/edit.html.erb_spec.rb
+++ b/spec/views/password_resets/edit.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "password_resets/edit.html.erb", type: :view do
+  # pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/password_resets/new.html.erb_spec.rb
+++ b/spec/views/password_resets/new.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "password_resets/new.html.erb", type: :view do
+  # pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/password_resets/update.html.erb_spec.rb
+++ b/spec/views/password_resets/update.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "password_resets/update.html.erb", type: :view do
+  # pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
### 実装した内容

**・パスワード再設定機能**
> 1.  メールアドレス入力画面
> 2. パスワード再設定メール送信（reset_token, reset_digestが生成される）
> 3. 送信されたメールのURLをクリック（URLにはreset_tokenが挿入されている）
> 4. パスワード再設定画面に遷移する（新しいパスワード入力）

**・パスワード再設定機能 RSpecテスト**
> 1. Requestスペック
> 2. maillerスペック（＝メール本文の内容確認 [※Base64のエンコード・デコードに注意！]）
