### PR TITLE
Add asset_path to image_tag

### DIFF
--- a/app/views/animes/show.html.erb
+++ b/app/views/animes/show.html.erb
@@ -35,7 +35,7 @@
         <% end %>
       </div>
       <div style="display:block;">
-        <%= image_tag 'coming_soon.png', :size =>'300x350', :style => 'display:block; margin:20px auto 20px auto;' %>
+        <%= image_tag(asset_path('coming_soon.png'), :size =>'300x350', :style => 'display:block; margin:20px auto 20px auto;') %>
       </div>
     </div>
     <div class="col-lg-7">


### PR DESCRIPTION
【修正】
・「image_tag('<画像のパス>')」→「image_tag(asset_path('<画像のパス>'))」